### PR TITLE
RMGDO-1194 Create svc_ansible user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
+<a name="v1.0.11"></a>
+## [v1.0.11] - 2023-02-07
+Changed
+- Replaced `nutanix` user with the new one
+- Locked `nutanix` user
+
 <a name="unreleased"></a>
 ## [Unreleased]
 


### PR DESCRIPTION
All our VMs which are created using common base image have `nutanix` user with sudo permissions and known password which is the same for all envs.
With this change we want to:
- create another user with the password we control and change from one env to another for ssh connections by `Terraform` and `Ansible`
- lock `nutanix` user as this one is compromised
- ensure all subsequent provisioning tasks use the new user